### PR TITLE
GH Actions: add a QA workflow for a typical PHPCS workflow

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches:
+      - latest
+  pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+name: qa
+jobs:
+  xmllint:
+    name: 'Check install and XML'
+    runs-on: ubuntu-latest
+
+    env:
+      XMLLINT_INDENT: '    '
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      # Validate the composer.json file.
+      # @link https://getcomposer.org/doc/03-cli.md#validate
+      - name: Validate Composer installation
+        run: composer validate --no-check-all --strict
+
+      # Install dependencies to make sure the PHPCS XSD file is available.
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Setup xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      # Show violations inline in the file diff.
+      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
+      - uses: korelstar/xmllint-problem-matcher@v1
+
+      # Validate the xml file.
+      # @link http://xmlsoft.org/xmllint.html
+      - name: Validate against schema
+        run: xmllint --noout --schema vendor/squizlabs/php_codesniffer/phpcs.xsd lib/phpDocumentor/ruleset.xml
+
+      # Check the code-style consistency of the xml file.
+      - name: Check code style
+        run: diff -B ./lib/phpDocumentor/ruleset.xml <(xmllint --format "./lib/phpDocumentor/ruleset.xml")

--- a/lib/phpDocumentor/ruleset.xml
+++ b/lib/phpDocumentor/ruleset.xml
@@ -1,25 +1,21 @@
 <?xml version="1.0"?>
-<ruleset
-        name="phpDocumentor"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd"
->
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="phpDocumentor" xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
     <description>The phpDocumentor coding standard.</description>
 
     <!-- Import Doctrine coding standard (base) -->
     <rule ref="Doctrine">
-        <exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame" />
-        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix" />
-        <exclude name="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint.UselessDocComment" />
+        <exclude name="Generic.Formatting.MultipleStatementAlignment.NotSame"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint.UselessDocComment"/>
 
         <!-- Disable param alignment in docblocks -->
-        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType" />
-        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName" />
+        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
+        <exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName"/>
     </rule>
 
     <rule ref="Generic.Formatting.SpaceAfterNot">
         <properties>
-            <property name="spacing" value="0" />
+            <property name="spacing" value="0"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
This workflow will:
* Validate the Composer dependencies and installation.
* Verify the XML ruleset against the PHPCS schema.
* Verify the XML ruleset for code style.

Opening as draft as this needs PR #28 to be merged first.